### PR TITLE
refactor: extract JavaPrivateKey and JavaPublicKey into separate files

### DIFF
--- a/projects/core/src/main/scala/crypto4s/JavaPrivateKey.scala
+++ b/projects/core/src/main/scala/crypto4s/JavaPrivateKey.scala
@@ -1,0 +1,10 @@
+package crypto4s
+
+import java.security.PrivateKey as JPrivateKey
+
+private[crypto4s] case class JavaPrivateKey[Alg](
+  delegate: JPrivateKey
+) extends PrivateKey[Alg] {
+
+  override def asJava: JPrivateKey = delegate
+}

--- a/projects/core/src/main/scala/crypto4s/JavaPublicKey.scala
+++ b/projects/core/src/main/scala/crypto4s/JavaPublicKey.scala
@@ -1,0 +1,10 @@
+package crypto4s
+
+import java.security.PublicKey as JPublicKey
+
+private[crypto4s] case class JavaPublicKey[Alg](
+  delegate: JPublicKey
+) extends PublicKey[Alg] {
+
+  override def asJava: JPublicKey = delegate
+}

--- a/projects/core/src/main/scala/crypto4s/PrivateKey.scala
+++ b/projects/core/src/main/scala/crypto4s/PrivateKey.scala
@@ -5,7 +5,7 @@ import java.security.PrivateKey as JPrivateKey
 import java.security.spec.InvalidKeySpecException
 import java.security.spec.PKCS8EncodedKeySpec
 
-sealed trait PrivateKey[Alg] { self =>
+trait PrivateKey[Alg] { self =>
   def decrypt[A: Deserializable](encrypted: Encrypted[Alg, A])(using
     decrypting: Decrypting[Alg, PrivateKey[Alg]]
   ): Either[RuntimeException, A] =
@@ -29,11 +29,4 @@ object PrivateKey {
   def fromJava[Alg](key: JPrivateKey): PrivateKey[Alg] = JavaPrivateKey(
     delegate = key
   )
-}
-
-private[crypto4s] case class JavaPrivateKey[Alg](
-  delegate: JPrivateKey
-) extends PrivateKey[Alg] {
-
-  override def asJava: JPrivateKey = delegate
 }

--- a/projects/core/src/main/scala/crypto4s/PublicKey.scala
+++ b/projects/core/src/main/scala/crypto4s/PublicKey.scala
@@ -29,10 +29,3 @@ object PublicKey {
     delegate = key
   )
 }
-
-private[crypto4s] case class JavaPublicKey[Alg](
-  delegate: JPublicKey
-) extends PublicKey[Alg] {
-
-  override def asJava: JPublicKey = delegate
-}


### PR DESCRIPTION
Move `JavaPrivateKey` and `JavaPublicKey` case classes out of `PrivateKey.scala` and `PublicKey.scala` into their own dedicated files, giving each type a single home for easier navigation and future changes.