### PR TITLE
refactor: replace RuntimeException with specific error types

### DIFF
--- a/projects/core/src/main/scala/crypto4s/Decrypting.scala
+++ b/projects/core/src/main/scala/crypto4s/Decrypting.scala
@@ -10,7 +10,9 @@ import javax.crypto.spec.GCMParameterSpec
 
 trait Decrypting[Alg, Key] {
   def decrypt(key: Key, data: Array[Byte]): Either[DecryptionException, Array[Byte]]
-  def decrypt[A](key: Key, encrypted: Encrypted[Alg, A])(using deserializable: Deserializable[A]): Either[DecryptionException | DeserializationException, A] =
+  def decrypt[A](key: Key, encrypted: Encrypted[Alg, A])(using
+    deserializable: Deserializable[A]
+  ): Either[DecryptionException | DeserializationException, A] =
     decrypt(key, encrypted.blob.toByteArray) match {
       case Left(e)      => Left(e)
       case Right(bytes) => deserializable.deserialize(bytes)

--- a/projects/core/src/main/scala/crypto4s/Decrypting.scala
+++ b/projects/core/src/main/scala/crypto4s/Decrypting.scala
@@ -9,17 +9,20 @@ import javax.crypto.IllegalBlockSizeException
 import javax.crypto.spec.GCMParameterSpec
 
 trait Decrypting[Alg, Key] {
-  def decrypt(key: Key, data: Array[Byte]): Either[RuntimeException, Array[Byte]]
-  def decrypt[A](key: Key, encrypted: Encrypted[Alg, A])(using deserializable: Deserializable[A]): Either[RuntimeException, A] =
-    decrypt(key, encrypted.blob.toByteArray).flatMap(deserializable.deserialize)
+  def decrypt(key: Key, data: Array[Byte]): Either[DecryptionException, Array[Byte]]
+  def decrypt[A](key: Key, encrypted: Encrypted[Alg, A])(using deserializable: Deserializable[A]): Either[DecryptionException | DeserializationException, A] =
+    decrypt(key, encrypted.blob.toByteArray) match {
+      case Left(e)      => Left(e)
+      case Right(bytes) => deserializable.deserialize(bytes)
+    }
 }
 
 object Decrypting {
   given Decrypting[AES, SecretKey[AES]] with {
-    override def decrypt(key: SecretKey[AES], data: Array[Byte]): Either[RuntimeException, Array[Byte]] = {
+    override def decrypt(key: SecretKey[AES], data: Array[Byte]): Either[DecryptionException, Array[Byte]] = {
       val minLength = AES.ivLength + AES.tagLength / 8
       if (data.length < minLength)
-        Left(new RuntimeException("Failed to decrypt"))
+        Left(new DecryptionException.InvalidCiphertext(s"Ciphertext too short: ${data.length} bytes, minimum $minLength"))
       else
         try {
           val iv         = data.take(AES.ivLength)
@@ -28,20 +31,20 @@ object Decrypting {
           cipher.init(Cipher.DECRYPT_MODE, key.asJava, new GCMParameterSpec(AES.tagLength, iv))
           Right(cipher.doFinal(ciphertext))
         } catch {
-          case e: AEADBadTagException       => Left(new RuntimeException("Failed to decrypt", e))
-          case e: IllegalBlockSizeException => Left(new RuntimeException("Failed to decrypt", e))
+          case e: AEADBadTagException       => Left(new DecryptionException.IntegrityCheckFailed(e))
+          case e: IllegalBlockSizeException => Left(new DecryptionException.InvalidCiphertext("Invalid ciphertext block size", e))
         }
     }
   }
 
   given Decrypting[RSA, PrivateKey[RSA]] with {
-    override def decrypt(key: PrivateKey[RSA], data: Array[Byte]): Either[RuntimeException, Array[Byte]] = try {
+    override def decrypt(key: PrivateKey[RSA], data: Array[Byte]): Either[DecryptionException, Array[Byte]] = try {
       val cipher = Cipher.getInstance(RSA.transformation)
       cipher.init(Cipher.DECRYPT_MODE, key.asJava)
       Right(cipher.doFinal(data))
     } catch {
-      case e: IllegalBlockSizeException => Left(new RuntimeException("Failed to decrypt", e))
-      case e: BadPaddingException       => Left(new RuntimeException("Failed to decrypt", e))
+      case e: IllegalBlockSizeException => Left(new DecryptionException.InvalidCiphertext("Invalid ciphertext block size", e))
+      case e: BadPaddingException       => Left(new DecryptionException.IntegrityCheckFailed(e))
     }
   }
 }

--- a/projects/core/src/main/scala/crypto4s/DecryptionException.scala
+++ b/projects/core/src/main/scala/crypto4s/DecryptionException.scala
@@ -1,12 +1,9 @@
 package crypto4s
 
-sealed abstract class DecryptionException(message: String, cause: Exception | Null)
-    extends Exception(message, cause)
+sealed abstract class DecryptionException(message: String, cause: Exception | Null) extends Exception(message, cause)
 
 object DecryptionException {
-  final class IntegrityCheckFailed(cause: Exception)
-      extends DecryptionException("Decryption integrity check failed", cause)
+  final class IntegrityCheckFailed(cause: Exception) extends DecryptionException("Decryption integrity check failed", cause)
 
-  final class InvalidCiphertext(message: String, cause: Exception | Null = null)
-      extends DecryptionException(message, cause)
+  final class InvalidCiphertext(message: String, cause: Exception | Null = null) extends DecryptionException(message, cause)
 }

--- a/projects/core/src/main/scala/crypto4s/DecryptionException.scala
+++ b/projects/core/src/main/scala/crypto4s/DecryptionException.scala
@@ -1,0 +1,12 @@
+package crypto4s
+
+sealed abstract class DecryptionException(message: String, cause: Exception | Null)
+    extends Exception(message, cause)
+
+object DecryptionException {
+  final class IntegrityCheckFailed(cause: Exception)
+      extends DecryptionException("Decryption integrity check failed", cause)
+
+  final class InvalidCiphertext(message: String, cause: Exception | Null = null)
+      extends DecryptionException(message, cause)
+}

--- a/projects/core/src/main/scala/crypto4s/Deserializable.scala
+++ b/projects/core/src/main/scala/crypto4s/Deserializable.scala
@@ -4,29 +4,29 @@ import crypto4s.algorithm.AES
 import crypto4s.algorithm.RSA
 
 trait Deserializable[A] {
-  def deserialize(a: Array[Byte]): Either[RuntimeException, A]
+  def deserialize(a: Array[Byte]): Either[DeserializationException, A]
 }
 
 object Deserializable {
   given Deserializable[Array[Byte]] with {
-    override def deserialize(a: Array[Byte]): Either[RuntimeException, Array[Byte]] = Right(a)
+    override def deserialize(a: Array[Byte]): Either[DeserializationException, Array[Byte]] = Right(a)
   }
   given Deserializable[String] with {
-    override def deserialize(a: Array[Byte]): Either[RuntimeException, String] = Right(new String(a))
+    override def deserialize(a: Array[Byte]): Either[DeserializationException, String] = Right(new String(a))
   }
   given Deserializable[PrivateKey[RSA]] with {
-    override def deserialize(a: Array[Byte]): Either[RuntimeException, PrivateKey[RSA]] =
-      PrivateKey.RSA(a).left.map(e => new RuntimeException("Failed to deserialize private key", e))
+    override def deserialize(a: Array[Byte]): Either[DeserializationException, PrivateKey[RSA]] =
+      PrivateKey.RSA(a).left.map(e => new DeserializationException.InvalidKeyBytes("RSA private key", e))
   }
   given Deserializable[SecretKey[AES]] with {
-    override def deserialize(a: Array[Byte]): Either[RuntimeException, SecretKey[AES]] =
-      SecretKey.AES(a).left.map(e => new RuntimeException("Failed to deserialize secret key", e))
+    override def deserialize(a: Array[Byte]): Either[DeserializationException, SecretKey[AES]] =
+      SecretKey.AES(a).left.map(e => new DeserializationException.InvalidKeyBytes("AES secret key", e))
   }
 }
 
 object DeserializableExtension extends DeserializableExtension
 trait DeserializableExtension {
   extension (a: Array[Byte]) {
-    def deserialize[A](using deserializable: Deserializable[A]): Either[RuntimeException, A] = deserializable.deserialize(a)
+    def deserialize[A](using deserializable: Deserializable[A]): Either[DeserializationException, A] = deserializable.deserialize(a)
   }
 }

--- a/projects/core/src/main/scala/crypto4s/DeserializationException.scala
+++ b/projects/core/src/main/scala/crypto4s/DeserializationException.scala
@@ -1,9 +1,7 @@
 package crypto4s
 
-sealed abstract class DeserializationException(message: String, cause: Exception | Null = null)
-    extends Exception(message, cause)
+sealed abstract class DeserializationException(message: String, cause: Exception | Null = null) extends Exception(message, cause)
 
 object DeserializationException {
-  final class InvalidKeyBytes(keyType: String, cause: Exception)
-      extends DeserializationException(s"Failed to deserialize $keyType", cause)
+  final class InvalidKeyBytes(keyType: String, cause: Exception) extends DeserializationException(s"Failed to deserialize $keyType", cause)
 }

--- a/projects/core/src/main/scala/crypto4s/DeserializationException.scala
+++ b/projects/core/src/main/scala/crypto4s/DeserializationException.scala
@@ -1,0 +1,9 @@
+package crypto4s
+
+sealed abstract class DeserializationException(message: String, cause: Exception | Null = null)
+    extends Exception(message, cause)
+
+object DeserializationException {
+  final class InvalidKeyBytes(keyType: String, cause: Exception)
+      extends DeserializationException(s"Failed to deserialize $keyType", cause)
+}

--- a/projects/core/src/main/scala/crypto4s/KeyPair.scala
+++ b/projects/core/src/main/scala/crypto4s/KeyPair.scala
@@ -8,7 +8,9 @@ case class KeyPair[Alg](
   publicKey: PublicKey[Alg]
 ) {
   def encrypt[A: BlobEncoder](a: A)(using Encrypting[Alg, PublicKey[Alg]]): Encrypted[Alg, A] = publicKey.encrypt(a)
-  def decrypt[A: Deserializable](encrypted: Encrypted[Alg, A])(using Decrypting[Alg, PrivateKey[Alg]]): Either[DecryptionException | DeserializationException, A] =
+  def decrypt[A: Deserializable](encrypted: Encrypted[Alg, A])(using
+    Decrypting[Alg, PrivateKey[Alg]]
+  ): Either[DecryptionException | DeserializationException, A] =
     privateKey.decrypt(encrypted)
 
   def sign[A: BlobEncoder, SignAlg](a: A)(using Signing[SignAlg, Alg]): Signed[SignAlg, A]                            = privateKey.sign(a)

--- a/projects/core/src/main/scala/crypto4s/KeyPair.scala
+++ b/projects/core/src/main/scala/crypto4s/KeyPair.scala
@@ -8,7 +8,7 @@ case class KeyPair[Alg](
   publicKey: PublicKey[Alg]
 ) {
   def encrypt[A: BlobEncoder](a: A)(using Encrypting[Alg, PublicKey[Alg]]): Encrypted[Alg, A] = publicKey.encrypt(a)
-  def decrypt[A: Deserializable](encrypted: Encrypted[Alg, A])(using Decrypting[Alg, PrivateKey[Alg]]): Either[RuntimeException, A] =
+  def decrypt[A: Deserializable](encrypted: Encrypted[Alg, A])(using Decrypting[Alg, PrivateKey[Alg]]): Either[DecryptionException | DeserializationException, A] =
     privateKey.decrypt(encrypted)
 
   def sign[A: BlobEncoder, SignAlg](a: A)(using Signing[SignAlg, Alg]): Signed[SignAlg, A]                            = privateKey.sign(a)

--- a/projects/core/src/main/scala/crypto4s/PrivateKey.scala
+++ b/projects/core/src/main/scala/crypto4s/PrivateKey.scala
@@ -8,7 +8,7 @@ import java.security.spec.PKCS8EncodedKeySpec
 sealed trait PrivateKey[Alg] { self =>
   def decrypt[A: Deserializable](encrypted: Encrypted[Alg, A])(using
     decrypting: Decrypting[Alg, PrivateKey[Alg]]
-  ): Either[RuntimeException, A] =
+  ): Either[DecryptionException | DeserializationException, A] =
     decrypting.decrypt(self, encrypted)
   def sign[A: BlobEncoder, SignAlg](a: A)(using signing: Signing[SignAlg, Alg]): Signed[SignAlg, A] = signing.sign[A](key = self, a = a)
 

--- a/projects/core/src/main/scala/crypto4s/SecretKey.scala
+++ b/projects/core/src/main/scala/crypto4s/SecretKey.scala
@@ -9,7 +9,7 @@ trait SecretKey[Alg] { self =>
     encrypting.encrypt(self, a)
   def decrypt[A: Deserializable](encrypted: Encrypted[Alg, A])(using
     decrypting: Decrypting[Alg, SecretKey[Alg]]
-  ): Either[RuntimeException, A] =
+  ): Either[DecryptionException | DeserializationException, A] =
     decrypting.decrypt(self, encrypted)
 
   def asJava: JSecretKey

--- a/projects/core/src/test/scala/crypto4s/KeyPairSpec.scala
+++ b/projects/core/src/test/scala/crypto4s/KeyPairSpec.scala
@@ -41,6 +41,17 @@ object KeyPairSpec extends ZIOSpecDefault {
       }
     }
 
+    test("decrypting with wrong key returns IntegrityCheckFailed") {
+      val keyPair1 = KeyPair.RSA()
+      val keyPair2 = KeyPair.RSA()
+
+      val encrypted = keyPair1.encrypt("secret")
+      val wrongKeyDecrypted = Encrypted[algorithm.RSA, String](encrypted.blob)
+      val result = keyPair2.privateKey.decrypt(wrongKeyDecrypted)
+
+      assertTrue(result.left.exists(_.isInstanceOf[DecryptionException.IntegrityCheckFailed]))
+    }
+
     test("RSA.transformation is compatible with bare RSA algorithm") {
       import javax.crypto.Cipher
       val keyPair = KeyPair.RSA()

--- a/projects/core/src/test/scala/crypto4s/KeyPairSpec.scala
+++ b/projects/core/src/test/scala/crypto4s/KeyPairSpec.scala
@@ -45,9 +45,9 @@ object KeyPairSpec extends ZIOSpecDefault {
       val keyPair1 = KeyPair.RSA()
       val keyPair2 = KeyPair.RSA()
 
-      val encrypted = keyPair1.encrypt("secret")
+      val encrypted         = keyPair1.encrypt("secret")
       val wrongKeyDecrypted = Encrypted[algorithm.RSA, String](encrypted.blob)
-      val result = keyPair2.privateKey.decrypt(wrongKeyDecrypted)
+      val result            = keyPair2.privateKey.decrypt(wrongKeyDecrypted)
 
       assertTrue(result.left.exists(_.isInstanceOf[DecryptionException.IntegrityCheckFailed]))
     }

--- a/projects/core/src/test/scala/crypto4s/SecretKeySpec.scala
+++ b/projects/core/src/test/scala/crypto4s/SecretKeySpec.scala
@@ -45,7 +45,15 @@ object SecretKeySpec extends ZIOSpecDefault {
         }
       }
 
-      test("tampered ciphertext returns Left") {
+      test("ciphertext too short returns InvalidCiphertext") {
+        val secretKey = SecretKey.AES()
+        val tooShort  = Encrypted[algorithm.AES, String](Blob.wrap(Array[Byte](1, 2, 3)))
+        val result    = secretKey.decrypt(tooShort)
+
+        assertTrue(result.left.exists(_.isInstanceOf[DecryptionException.InvalidCiphertext]))
+      }
+
+      test("tampered ciphertext returns IntegrityCheckFailed") {
         val secretKey = SecretKey.AES()
 
         check(Gen.alphaNumericStringBounded(1, 256)) { data =>
@@ -55,7 +63,7 @@ object SecretKeySpec extends ZIOSpecDefault {
           val tampered = Encrypted[algorithm.AES, String](Blob.wrap(bytes))
 
           val result = secretKey.decrypt(tampered)
-          assertTrue(result.isLeft)
+          assertTrue(result.left.exists(_.isInstanceOf[DecryptionException.IntegrityCheckFailed]))
         }
       }
     }


### PR DESCRIPTION
Replace generic `RuntimeException` with `DecryptionException` and `DeserializationException` sealed hierarchies so callers can pattern-match on failure causes instead of inspecting message strings.