### PR TITLE
chore: address review comments from AES-GCM PR

### DIFF
--- a/projects/core/src/main/scala/crypto4s/Decrypting.scala
+++ b/projects/core/src/main/scala/crypto4s/Decrypting.scala
@@ -2,7 +2,6 @@ package crypto4s
 
 import crypto4s.algorithm.AES
 import crypto4s.algorithm.RSA
-import javax.crypto.AEADBadTagException
 import javax.crypto.BadPaddingException
 import javax.crypto.Cipher
 import javax.crypto.IllegalBlockSizeException
@@ -28,7 +27,7 @@ object Decrypting {
           cipher.init(Cipher.DECRYPT_MODE, key.asJava, new GCMParameterSpec(AES.tagLength, iv))
           Right(cipher.doFinal(ciphertext))
         } catch {
-          case e: AEADBadTagException       => Left(new RuntimeException("Failed to decrypt", e))
+          case e: BadPaddingException        => Left(new RuntimeException("Failed to decrypt", e))
           case e: IllegalBlockSizeException => Left(new RuntimeException("Failed to decrypt", e))
         }
     }

--- a/projects/core/src/main/scala/crypto4s/Decrypting.scala
+++ b/projects/core/src/main/scala/crypto4s/Decrypting.scala
@@ -27,7 +27,7 @@ object Decrypting {
           cipher.init(Cipher.DECRYPT_MODE, key.asJava, new GCMParameterSpec(AES.tagLength, iv))
           Right(cipher.doFinal(ciphertext))
         } catch {
-          case e: BadPaddingException        => Left(new RuntimeException("Failed to decrypt", e))
+          case e: BadPaddingException       => Left(new RuntimeException("Failed to decrypt", e))
           case e: IllegalBlockSizeException => Left(new RuntimeException("Failed to decrypt", e))
         }
     }

--- a/projects/core/src/main/scala/crypto4s/Encrypting.scala
+++ b/projects/core/src/main/scala/crypto4s/Encrypting.scala
@@ -13,10 +13,12 @@ trait Encrypting[Alg, Key] {
 }
 
 object Encrypting {
+  private val secureRandom = new SecureRandom()
+
   given Encrypting[AES, SecretKey[AES]] with {
     override def encrypt(key: SecretKey[AES], data: Array[Byte]): Array[Byte] = {
       val iv = new Array[Byte](AES.ivLength)
-      new SecureRandom().nextBytes(iv)
+      secureRandom.nextBytes(iv)
       val cipher = Cipher.getInstance(AES.transformation)
       cipher.init(Cipher.ENCRYPT_MODE, key.asJava, new GCMParameterSpec(AES.tagLength, iv))
       val ciphertext = cipher.doFinal(data)

--- a/projects/core/src/main/scala/crypto4s/SecretKey.scala
+++ b/projects/core/src/main/scala/crypto4s/SecretKey.scala
@@ -28,7 +28,7 @@ object SecretKey {
 
   def AES(key: Array[Byte]): Either[IllegalArgumentException, SecretKey[algorithm.AES]] = {
     if (!validAESKeyLengths.contains(key.length))
-      Left(new IllegalArgumentException(s"Invalid AES key length: ${key.length} bytes"))
+      Left(new IllegalArgumentException(s"Invalid AES key length: ${key.length} bytes (must be 16, 24, or 32)"))
     else
       try {
         Right(fromJava(new SecretKeySpec(key, "AES")))


### PR DESCRIPTION
Address review feedback from #113: catch BadPaddingException instead of AEADBadTagException, reuse SecureRandom instance, and improve AES key length error message.